### PR TITLE
zmiana apiVersion na apps/v1

### DIFF
--- a/sezon-1/3-replicaset/fussy-autoscaled-rs.yaml
+++ b/sezon-1/3-replicaset/fussy-autoscaled-rs.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: fussy-autoscaled

--- a/sezon-1/3-replicaset/nginx-rs.yaml
+++ b/sezon-1/3-replicaset/nginx-rs.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: nginxrs


### PR DESCRIPTION
Zgodnie z tym co udało mi się znaleźć - https://stackoverflow.com/questions/64412740/no-matches-for-kind-replicaset-in-version-extensions-v1beta1 - od wersji 1.16 ReplicaSet zostało przeniesione do apps/v1. 